### PR TITLE
fix: target include directory is the root folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,4 +9,4 @@ set(CMAKE_CXX_STANDARD 17)
 add_library (arduino-wm8960 mtb_wm8960.cpp)
 
 # define location for header files
-target_include_directories(arduino-wm8960 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src )
+target_include_directories(arduino-wm8960 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} )


### PR DESCRIPTION
Just fix the target_include_directory that is not the `src` folder in the `CMAKE_CURRENT_SOURCE_DIR`.